### PR TITLE
Add SwiftOSLog and SwiftDataDetection frameworks to fix linking error on macOS.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -233,6 +233,8 @@ fn addLibrariesOSX (b: *Build, target: Build.ResolvedTarget, exe: *Build.Step.Co
     exe.linkSystemLibrary("swiftCoreImage");
     exe.linkSystemLibrary("swiftDarwin");
     exe.linkSystemLibrary("swiftUniformTypeIdentifiers");
+    exe.linkSystemLibrary("swiftDataDetection");
+    exe.linkSystemLibrary("swiftOSLog");
 }
 
 fn importModulesToEachOtherAndToRoot (root_module: *Build.Module, modules: []const struct { name: []const u8, module: *Build.Module }) void


### PR DESCRIPTION
Added SwiftOSLog and SwiftDataDetection frameworks to fix linking error when attempting to build on macOS.